### PR TITLE
Modified get_leaderboard to accept pagination

### DIFF
--- a/ajobot_manager/manager.py
+++ b/ajobot_manager/manager.py
@@ -87,8 +87,10 @@ class AjoManager:
 
         return res
 
-    async def get_leaderboard(self) -> dict:
-        data = await self.redis.zrange(LEADERBOARD, 0, 9, "rev", "withscores")
+    async def get_leaderboard(self, page: int = 1, items_per_page: int = 10) -> dict:
+        page_to = (page*items_per_page)-1
+        page_from = page_to-9
+        data = await self.redis.zrange(LEADERBOARD, page_from, page_to, "rev", "withscores")
 
         ids = []
         scores = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ajobot-manager"
-version = "1.0.1"
+version = "1.1.0"
 description = "An interface for the different ajobots"
 authors = [
     "Axel Amigo Arnold <axl89@users.noreply.github.com>",


### PR DESCRIPTION
This function now accepts the `page` and `items_per_page` integer arguments with default values being retrocompatible.