### PR TITLE
Fix corner case

### DIFF
--- a/ajobot_manager/manager.py
+++ b/ajobot_manager/manager.py
@@ -102,7 +102,12 @@ class AjoManager:
         res = {}
         i = 0
         for i in range(len(names)):
-            name = names[i].decode("utf-8")
+            # Corner case when it's None
+            # (e.g. we don't have the name of the id of the user)
+            if not names[i]:
+                name = "Unknown player"
+            else:
+                name = names[i].decode("utf-8")
             res[name] = scores[i]
             i += 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ajobot-manager"
-version = "1.1.0"
+version = "1.1.1"
 description = "An interface for the different ajobots"
 authors = [
     "Axel Amigo Arnold <axl89@users.noreply.github.com>",


### PR DESCRIPTION
Fixed below corner case:

```
127.0.0.1:6379> "MGET" "529328883284181017" "391996245167570956" "324626437988417536" "229339523950051332" "1029109307289129070" "415079938002124800" "99266052151599104" "683410753641906207" "621057338962608158" "523066936792186880"
 1) "Carl4s#5744"
 2) (nil)
 3) "Rst001#0001"
 4) "Skinner#8015"
 5) "mr.kavosh#6768"
 6) "Joaquim#0228"
 7) "fabri2000779#3306"
 8) "tremendolio#1115"
 9) "Milady#5430"
10) "jjotah#1746"
```