### PR TITLE
fix: corner case with multiple uknown in lb

### DIFF
--- a/ajobot_manager/manager.py
+++ b/ajobot_manager/manager.py
@@ -111,7 +111,7 @@ class AjoManager:
             # Corner case when it's None
             # (e.g. we don't have the name of the id of the user)
             if not names[i]:
-                name = "Unknown player"
+                name = f"Unknown player ({ids[i][-4:]})"
             else:
                 name = names[i].decode("utf-8")
             res[name] = scores[i]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ajobot-manager"
-version = "1.2.1"
+version = "1.2.2"
 description = "An interface for the different ajobots"
 authors = [
     "Axel Amigo Arnold <axl89@users.noreply.github.com>",


### PR DESCRIPTION
If two or more unknown users were in the names array, their data would collide in the res associative array, causing the latest unknown player's score to be set.